### PR TITLE
style: make the text body more narrow

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -127,6 +127,8 @@ main {
   font-size: 1.2rem;
   color: #2f2f2f;
   padding: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
 }
 
 .content p {


### PR DESCRIPTION
Makes it easier to read in my opinion.

Before:

![cdli-gh github io_blog_gsoc20_api_posts_results](https://user-images.githubusercontent.com/14018963/91640884-0fe97580-ea21-11ea-8a14-371f74654d31.png)

After:

![cdli-gh github io_blog_gsoc20_api_posts_results (1)](https://user-images.githubusercontent.com/14018963/91640886-12e46600-ea21-11ea-8e60-0eb5817b7ecf.png)
